### PR TITLE
Sanitize thoughts before sending them in the thought's channel

### DIFF
--- a/bot/core.py
+++ b/bot/core.py
@@ -61,6 +61,9 @@ Enjoy!
             async with message.channel.typing():
                 thought, response = await BLOOM_CHAIN.chat(LOCAL_CHAIN, inp)
 
+            # sanitize thought by adding zero width spaces to triple backticks
+            thought = thought.replace("```", "`\u200b`\u200b`")
+
             thought_channel = self.bot.get_channel(int(THOUGHT_CHANNEL))
 
             # Thought Forwarding


### PR DESCRIPTION
Sanitizes thoughts before sending them in the thoughts channel to prevent discord formatting issues.

For example, this message would have caused issues before because of the triple backticks but it works now.
<img width="1126" alt="image" src="https://github.com/plastic-labs/tutor-gpt/assets/35976702/b1599c08-31f7-4cbc-b2ff-89e7949cf116">
